### PR TITLE
Fix output.write bug on macOS Python3 environment

### DIFF
--- a/v1/process_wiki.py
+++ b/v1/process_wiki.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     wiki = WikiCorpus(inp, lemmatize=False, dictionary={})
     for text in wiki.get_texts():
         if six.PY3:
-            output.write(b' '.join(text).decode('utf-8') + '\n')
+            output.write(bytes(' '.join(text), 'utf-8').decode('utf-8') + '\n')
         #   ###another method###
         #    output.write(
         #            space.join(map(lambda x:x.decode("utf-8"), text)) + '\n')


### PR DESCRIPTION
b' '  to bytes()

Old: `output.write(b' '.join(text).decode('utf-8') + '\n')`

New: `output.write(bytes(' '.join(text), 'utf-8').decode('utf-8') + '\n')`